### PR TITLE
API prediction endpoint fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
             - --max-locals=30
             - --ignore-imports=yes
             - --disable=redefined-outer-name
+            - --disable=duplicate-code
           
       
       - id: pynblint

--- a/notebooks/5.0-aag-ji-app.ipynb
+++ b/notebooks/5.0-aag-ji-app.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -25,7 +25,7 @@
        "True"
       ]
      },
-     "execution_count": 74,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -42,6 +42,9 @@
     "# Load packages\n",
     "from torchinfo.layer_info import LayerInfo\n",
     "import torchinfo\n",
+    "from torchvision import transforms\n",
+    "import pickle\n",
+    "\n",
     "\n",
     "from mdsist.dataset import MdsistDataset\n",
     "from mdsist.config import DATA_DIR, PROCESSED_DATA_DIR\n",
@@ -69,13 +72,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "49ca3166b89a4a95b8d7a1783f88984f",
+       "model_id": "833dd6e1b7724949b440f21999991367",
        "version_major": 2,
        "version_minor": 0
       },
@@ -101,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,13 +151,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f711f2b5b2954062894eea5d6d01492a",
+       "model_id": "b1b13b9045204cd4983a0d9a7c0424f9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -180,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,7 +195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -271,7 +274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,30 +285,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def get_img_bytes(ind):\n",
-    "    test_dataset = MdsistDataset(PROCESSED_DATA_DIR / 'test.parquet')\n",
-    "    image_dict = test_dataset.data.loc[ind, \"image\"]\n",
-    "    image_array = test_dataset.decode_png_image(image_dict)\n",
-    "    image = image_array.tobytes()\n",
-    "    # Plot the image\n",
-    "    plt.imshow(image_array, cmap='gray')\n",
-    "    plt.axis('off')\n",
-    "    plt.show()\n",
-    "    return image"
+    "def get_img_bytes(inds):\n",
+    "    transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.5,), (0.5,))])\n",
+    "    test_dataset = MdsistDataset(PROCESSED_DATA_DIR / 'test.parquet',transform=transform)\n",
+    "    images= []\n",
+    "\n",
+    "    for ind in inds:\n",
+    "        image_dict = test_dataset.data.loc[ind, \"image\"]\n",
+    "        image_array = np.array([test_dataset.decode_png_image(image_dict)])\n",
+    "        #print(image_array)\n",
+    "        plt.imshow(image_array[0], cmap='gray')\n",
+    "        plt.axis('off')\n",
+    "        plt.show()\n",
+    "        images.append(image_array)\n",
+    "\n",
+    "    #print(np.array(images).shape)\n",
+    "    return np.array(images).dumps()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAGFCAYAAAASI+9IAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAIoUlEQVR4nO3cP2tVWR+G4b0lEFOIEIOFNooWIqIIiljYaWUZMXb6IQRBOwXB2Fhpa+e/SghITKMimEJQGyu1tFESLBSCes50D+8LFue3M+fETK6rzsPazETvWcWstt/v9xsAaJpm01p/AAB/D1EAIEQBgBAFAEIUAAhRACBEAYAQBQBibNAfbNt2mN8BwJAN8v8quykAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAxttYfwJ9NTk522s3MzJQ3ly9fLm927NhR3oxS27blzYcPH8qbx48flzd3794tb5qm2/etrKx0OouNy00BgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgGj7/X5/oB/s8Ook3c3Pz3fanTx5srwZ8Ffg/7x//768WVhYKG+apmk+ffpU3pw4caLTWVX79+8fyaZpmub169flTZffoydPnpQ3i4uL5Q2jN8ifdTcFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgPAg3gjs27evvHn27FmnsyYnJ8ubK1eulDe3b98ub75//17e/O22bdtW3szOznY66/z58+VNlz+3jx49Km/OnTtX3jB6HsQDoEQUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBhb6w9Yb7Zu3VrezM/PlzdTU1PlTdM0za1bt8qbmzdvdjqLpvn161d5s3v37iF8Cfw73BQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAwoN4RePj4+XNzp07h/Alf/bx48eRnfVfs3fv3vLm4cOH5c3BgwfLm1G6f//+Wn8Ca8hNAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYDwSuoItG07srMePHgwsrNGpcvrpTMzM+XN1atXy5t3796VN2fOnClvmqZprl27Vt4cOHCgvFleXi5v+O9wUwAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAID+KNQL/fH9lZN27cKG/u3LlT3nR5aO3ChQvlTdM0zZEjR8qb379/lzfXr18vb7o8ovfz58/ypmm6PYjX6/U6ncXG5aYAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEG1/wNfa2rYd9resC5s21Tt68eLF8qbL42dN0zRjY/U3Dn/8+FHeTExMlDddH4J7+fJleXP27NnyZnl5ubzpYteuXZ12i4uL5c3S0lJ5c+jQofKm679bRmuQv+7dFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQCi/nraBtfr9cqb2dnZ8ubt27flTdM0zenTp8ubzZs3lzcLCwvlzZcvX8qbpmma58+fd9r9rbo+iDc1NVXedPln7nG7jc1NAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACA8iPeXevr06Uh3AE3jpgDA/xAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgPBKKqzC2Fj9j9ClS5c6ndW2bXmzvLzc6Sw2LjcFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgPAgHqzC5ORkeXPq1KlOZ/X7/fLm3r17nc5i43JTACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAgP4sEq9Hq98mZlZaXTWePj4512UOGmAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABAexINV+Pr1a3kzNzfX6azp6elOO6hwUwAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAID+LBKkxMTJQ3e/bsGcKXwL/DTQGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGA8EoqrMKWLVvKm8OHDw/hS/5s0yb/3UeN3xgAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGA8CAejFi/3x/ZWb1eb2Rn8d/gpgBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQbX/A17nath32t8C6s3379vLm8+fPQ/iSP3vz5k15c/To0SF8CX+DQf66d1MAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQAiLG1/gBYz759+1bevHr1qtNZx48fL2+WlpY6ncXG5aYAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQLT9fr8/0A+27bC/BTaEY8eOddrNzc2VN9PT0+XNixcvyhvWh0H+undTACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAgP4gFsEB7EA6BEFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAYG/QHB3w3D4B1zE0BgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGA+Af2jgVcfuXFLgAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAGFCAYAAAASI+9IAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAJUklEQVR4nO3cP2jV5x7H8d+RoBZSKehSLGotFFR0sohDoSCiIjiULh3azUkaFBXFQWkHweqSqVspCOLmIOgQ/4CYoa2UiLSDk6UGO/gHISIE4XeXy4de9ML5/m5Oknt8vebz4TxDzDvP4NNr27ZtAKBpmiULfQAAFg9RACBEAYAQBQBCFAAIUQAgRAGAEAUAYqTfD/Z6vUGeA4AB6+f/KrspABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQIwt9AFgsTp06Vd789ttv5c3ly5fLm2F08uTJTrtvv/22vPnkk0/Kmzt37pQ3w8BNAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACA8iAf/9uTJk/Lmyy+/LG+G8UG89evXlzfHjx/v9F1t23ba0R83BQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYDwIB5Dae3ateXNwYMHy5s7d+6UN8NofHy8vFm+fHmn75qeni5vXr582em73kZuCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEV1JZ9EZHR8ubGzdulDcrVqwob44dO1beLHbbtm0rb3bu3DmAk7zZjz/+WN788ccfAzjJcHJTACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAgP4jFvli5d2ml36dKl8ubDDz8sbx48eFDezM7OljfzqdfrlTeffvppebNkSf3vy5mZmfKmabr9PLRt2+m73kZuCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgDhQTzmzdGjRzvtduzYMccnebMDBw6UN48ePRrASebOO++8U958//33AzjJ6y5cuNBpNzU1NbcH4T+4KQAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEB/Ho5Ny5c+XN2NhYp+969epVeTM+Pl7eTExMlDfzac2aNeXN2bNnB3CS101OTpY3XX8eGCw3BQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQCi17Zt29cHe71Bn4U5sH79+vLm/Pnz5c3mzZvLm9HR0fKmaZpmZmamvNm0aVN58+jRo/LmvffeK2++++678qZpmuaLL74ob1atWlXezM7Oljdbtmwpb+7fv1/e8L/p59e9mwIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAjCz0AZhbx44dK2+2b98+gJO8bmpqqtPuzJkz5c1ff/1V3ly5cqW82b17d3mz2P3+++/ljQczh4ebAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAEB4EG+R2rVrV6fd119/PccnmTtjY2OdduvWrStv7t27V95s3LixvBlGjx8/Lm8ePHgw9wdhQbgpABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAESvbdu2rw/2eoM+y9B69913y5tff/2103d9/PHHnXY0zQ8//FDe7Nu3r7xZvXp1edPV3bt3y5sjR46UN9evXy9vmH/9/Lp3UwAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFACIkYU+wNvg888/L2+G8WG7Z8+eddpdu3atvLl48WJ5c+vWrfJmw4YN5U3XB/EmJyfLm2+++aa8mZqaKm8YHm4KAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIRXUufB9PR0efPw4cNO33X16tXy5v79++XNxMREefPnn3+WN03TNM+fP++0q9q/f39589lnn839Qf6Lc+fOlTdePKXKTQGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgem3btn19sNcb9Fn4h5UrV3baPX36tLzp80fg/8pHH31U3ty8ebO8+eCDD8qbEydOlDdN0zQ//fRTefP33393+i6GUz//1t0UAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAGJkoQ/Amz158mShj7BoLF++vLw5e/ZsedPlcbsXL16UN7dv3y5vmsbjdswPNwUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGA8CAei96WLVvKmz179gzgJK/76quvypuuD+LBfHBTACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAgP4jFvlizp9jfI4cOHy5tly5aVN23bljfvv/9+eQOLmZsCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCANFr+3wastfrDfosDLmtW7d22v3yyy9zfJI3Gx8fL28OHTo0gJPAYPTz695NAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACA8iMe8mZiY6LTbsWNHefPzzz+XN3v37i1vnj59Wt7AQvEgHgAlogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgDEyEIfgLfH8+fP5+27Tp8+Xd543A7cFAD4B1EAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAote2bdvXB3u9QZ8FgAHq59e9mwIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAECP9frBt20GeA4BFwE0BgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGA+Be+aSwR1YLP0AAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAGFCAYAAAASI+9IAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAIqUlEQVR4nO3csavN8R/H8c/hyiSxXZdyBxxhNjCyGO4ki9xF146BRSZFFv+ArlDuwmRAIouBRdRNRJEbpWxKDN/f9upXP/U775PjcD0e83l1PoPO834Gn17XdV0DgNbainEfAIA/hygAEKIAQIgCACEKAIQoABCiAECIAgAxMegHe73eKM8BwIgN8n+V3RQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgJgY9wFgFLZt21bePHjwoLzZsGFDeTOsCxculDenT58ewUlYztwUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAMKDeCxLc3Nz5c3k5GR5c/369fJmaWmpvGmttQ8fPgy1gwo3BQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYDodV3XDfTBXm/UZ4GfunjxYnlz/Pjx8mbFivrfSHv37i1vHj9+XN7ArzDIz72bAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAEBMjPsA/Du2bt061O7IkSPlzTCP250/f768efr0aXkDfzI3BQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYDodV3XDfTBXm/UZ2GZe/78+VC7nTt3ljd3794tb2ZmZsqbHz9+lDcwLoP83LspABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABAT4z4Af6dDhw6VN/1+fwQn+bknT56UN148BTcFAP6LKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgDhQTyGsmbNmvJmYmK4f24fPnwoby5fvjzUd8G/zk0BgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIDyIx1D6/f5v+675+fny5v379yM4CSx/bgoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIA0eu6rhvog73eqM/CX2Rpaam8mZycHOq7hnl879WrV0N9Fyxng/zcuykAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEBPjPgDjNzU1Vd6sXr16BCcBxs1NAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACA8iEebmZkpb9avXz+CkwDj5qYAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEB7Eo33+/Lm8+fHjR3mzatWq8uZ3Wrt2bXmzZcuW8ubo0aPlTWutTU9PD7WrunLlSnmzsLDw6w/CWLgpABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAESv67puoA/2eqM+C3+RpaWl8mZycnKo7+r3++XNunXryptLly6VN7t37y5vvn79Wt601tqbN2/Km82bN5c3K1bU/1a8detWeXPixInyprXWvnz5MtSO1gb5uXdTACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAIiJcR8A/p+5ubny5u3bt+XNzp07y5uTJ0+WN8+ePStvWmvt4cOH5c2ePXvKm1OnTpU3s7Oz5c2jR4/Km9Zam5+fH2rHYNwUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAIhe13XdQB/s9UZ9Fv4iL168KG927NgxgpP8Ojdu3ChvDh8+PIKTjFe/3y9vFhcXy5s7d+6UN621duDAgaF2tDbIz72bAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAEBMjPsA/J3OnTtX3ly7dm2o71q5cmV58+3bt/LmwoUL5Q3D27Vr17iPwE+4KQAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEB/EYysLCQnlz5syZob5r+/bt5c2nT5/Km+/fv5c3f7qtW7eWN2fPnh3BSf7X7du3f8v3UOOmAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABC9ruu6gT7Y6436LCxz/X5/qN29e/fKm40bN5Y37969K28uXbpU3szPz5c3rbU2Oztb3hw/fry8mZ6eLm8+fvxY3uzfv7+8aa21xcXFoXa0NsjPvZsCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQHgQjz/etm3bypv79++XN1NTU+XNcvTp06fyZt++feWNh+1+Pw/iAVAiCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgDhlVSWpWFeVj148GB5c+zYsfJm06ZN5U1rrV29erW8ef36dXlz8+bN8ubly5flDb+fV1IBKBEFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIDyIB/CP8CAeACWiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQE4N+sOu6UZ4DgD+AmwIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgDxH4+x/8VIiICcAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
       ]
@@ -316,46 +335,46 @@
     {
      "data": {
       "text/plain": [
-       "b'\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x12i\\xe3\\xfd\\xfd\\xfd\\xfe\\xda\\x8b+\\x07\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xb9\\xfd\\xfc\\xd2\\x8dk\\xa8\\xa8\\xd2\\xfc\\xc8\\x819\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00)\\xe8\\xfau\\x0b\\x00\\x00\\x00\\x00\\x13\\x9d\\xfc\\xfd\\xa8\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0f\\xe1\\xfc\\x8c\\x00\\x00\\x00\\x00\\x00\\x00\\x0f\\xbe\\xfc\\xfd\\xa8\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x16\\xfc\\xfcj\\x00\\x00\\x00\\x00\\x00$\\xce\\xfc\\xfc\\xfdP\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x16\\xfd\\xfd\\x12\\x00\\x00\\x00${\\xfd\\xceP\\xd4\\xff?\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x16\\xfc\\xfc\\x9b2^\\xbe\\xf2\\xef\\x84\\x05\\x00\\xd3\\xfd?\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02v\\xf9\\xfd\\xf4\\xfc\\xf7\\xbb\\x11\\x00\\x00 \\xe8\\xd6\\x05\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00F\\x91\\x99T?\\x00\\x00\\x00\\x00@\\xfc\\xd3\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00@\\xfc\\xd3\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x04\\xb7\\xfd\\xc2\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x16\\xfc\\xfcj\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x14\\xf5\\xfcj\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xa9\\xfcj\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\t\\xcc\\xfcj\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x16\\xfd\\xfdk\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x16\\xfc\\xfcj\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x16\\xfc\\xfc\\xcb\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x07\\xc4\\xfc\\xb9\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x007\\xeb>\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00'"
+       "b'\\x80\\x02cnumpy.core.multiarray\\n_reconstruct\\nq\\x00cnumpy\\nndarray\\nq\\x01K\\x00\\x85q\\x02c_codecs\\nencode\\nq\\x03X\\x01\\x00\\x00\\x00bq\\x04X\\x06\\x00\\x00\\x00latin1q\\x05\\x86q\\x06Rq\\x07\\x87q\\x08Rq\\t(K\\x01(K\\x02K\\x01K\\x1cK\\x1ctq\\ncnumpy\\ndtype\\nq\\x0bX\\x02\\x00\\x00\\x00u1q\\x0c\\x89\\x88\\x87q\\rRq\\x0e(K\\x03X\\x01\\x00\\x00\\x00|q\\x0fNNNJ\\xff\\xff\\xff\\xffJ\\xff\\xff\\xff\\xffK\\x00tq\\x10b\\x89h\\x03X\\xdb\\x06\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x7fM\\x00\\x00\\x00\\x00\\x00~\\xc3\\xbf4\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00l\\xc2\\xa6\\x00\\x00\\x00\\x00\"\\xc3\\xb6\\xc3\\xbe4\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x1f\\xc3\\x9c\\xc2\\xa8\\x00\\x00\\x00\\x00\\xc2\\xb4\\xc3\\xbe\\xc3\\xa4+\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0c\\xc3\\x9d\\xc3\\xab\\x1f\\x00\\x00\\x007\\xc3\\xb8\\xc3\\xbe\\xc2\\x81\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x06\\xc2\\xbb\\xc3\\xbe\\xc3\\x9e\\x19\\x00\\x00\\x01t\\xc3\\xba\\xc3\\xb20\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00{\\xc3\\xbe\\xc3\\xbeJ\\x00\\x00\\x00\\n\\xc3\\xbe\\xc3\\xbe\\xc2\\x98\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xc2\\x8c\\xc3\\xba\\xc3\\xba\\xc2\\x8b\\x04\\x00\\x00\\x1e\\xc2\\xa9\\xc3\\xbe\\xc3\\x84\\x06\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\"\\xc3\\x85\\xc3\\xb2\\xc3\\xbe\\xc3\\xb2\\x1d\\x04\\x14\\xc2\\x96\\xc3\\xaa\\xc3\\xbe\\xc3\\xb8&\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xc2\\x99\\xc3\\xbe\\xc3\\xbe\\xc3\\x8eW\\x00\\xc2\\xb6\\xc3\\xbe\\xc3\\xbe\\xc3\\xbe\\xc3\\xbe\\xc3\\x8d\\'\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00G\\xc3\\xb7\\xc3\\xbe\\xc3\\xbe=\\\\\\xc3\\x93\\xc3\\xbd\\xc3\\xbe\\xc3\\xbe\\xc3\\xbe\\xc3\\xbe\\xc2\\xb9\\x07\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\r\\xc3\\x98\\xc3\\xbe\\xc3\\xbe\\xc3\\xbe\\xc3\\xbe\\xc3\\xbe\\xc3\\xbe\\xc2\\x95\\xc3\\xa4\\xc3\\xbe\\xc3\\xbe\\xc3\\x8fC\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00_\\xc3\\xbe\\xc3\\xbe\\xc3\\xbe\\xc3\\xbe\\xc3\\xad\\xc2\\xa9Q\\x13\\xc2\\xbe\\xc3\\xbe\\xc3\\x830\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00D\\xc3\\xa2\\xc2\\x99s.\\x0f\\x00\\x00e\\xc3\\xbe\\xc3\\xbeO\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x13\\x01\\x00\\x00\\x00\\x00#\\xc3\\xa2\\xc3\\xbex\\x18\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x08\\xc2\\xae\\xc3\\xbe\\xc3\\xb4<\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x006\\xc3\\xb7\\xc3\\xbeP\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\xc2\\xa9\\xc3\\xbe\\xc3\\xbdi\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x005\\xc3\\xbe\\xc3\\xbe\\xc2\\x8f\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xc2\\xbb\\xc3\\xbe\\xc3\\x87\\x12\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xc2\\xac\\xc3\\xbeM\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\'\\xc3\\xa4\\xc3\\xbe\\xc3\\xbe\\xc2\\x87\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xc2\\x8b\\xc3\\xbd\\xc2\\xa2\\xc2\\x87l\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xc2\\x8a\\xc3\\xbb\\xc3\\xbd:\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00&\\xc3\\xa7\\xc3\\xbd\\xc2\\x85\\x05\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xc3\\x91\\xc3\\xbd\\xc2\\xb6\\x05\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00V\\xc3\\xb9\\xc3\\xbd\\xc2\\x80\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00c\\xc3\\xbd\\xc3\\xa1\\x1e\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xc2\\x8a\\xc3\\xbd\\xc2\\x80\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xc3\\xa4\\xc3\\xbd&\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x1b\\xc3\\xab\\xc3\\xbd&\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00i\\xc3\\xbd\\xc3\\xbd&\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00T\\xc3\\xb8\\xc3\\xbd&\\x00\\x0f5\\xc2\\x96\\xc2\\xb7\\xc2\\xb7X\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xc3\\xa4\\xc3\\xbd&7\\xc3\\x86\\xc3\\xbd\\xc3\\xb3\\xc3\\x8f\\xc3\\xaf\\xc3\\xb1\\xc2\\x9f\\x12\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xc3\\xa4\\xc3\\xbd\\xc2\\x8aj\\xc3\\xb2rA\\x00;\\xc2\\xb1\\xc3\\xbda\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xc3\\x93\\xc3\\xbd\\xc3\\xbd\\xc3\\xbd\\xc2\\xa4\\x00\\x00\\x00\\x00(\\xc3\\xbd\\xc2\\xb5\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00X\\xc3\\xba\\xc3\\xbd\\xc3\\xb5.\\x00\\x00\\x00\\x00(\\xc3\\xbd\\xc3\\xa3\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xc3\\x94\\xc3\\xbd\\xc3\\x9d)\\x00\\x00\\x00&\\xc2\\xa6\\xc3\\xbd\\xc2\\x96\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00(\\xc3\\xa1\\xc3\\xbd\\xc3\\x9eo\\x0el\\xc3\\x9c\\xc3\\xbd\\xc3\\xa4*\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\'\\xc3\\xa2\\xc3\\xbd\\xc3\\xbd\\xc3\\xbd\\xc3\\xbd\\xc3\\xbd\\xc3\\xa5*\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\'{\\xc3\\xa0\\xc3\\xbd\\xc2\\x9f{)\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00q\\x11h\\x05\\x86q\\x12Rq\\x13tq\\x14b.'"
       ]
      },
-     "execution_count": 83,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "get_img_bytes(4)"
+    "get_img_bytes([6,7])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "It works\n"
+      "{'message': 'OK', 'status-code': 200, 'data': {'message': 'Welcome. See /docs for more information about the api'}}\n"
      ]
     }
    ],
    "source": [
-    "response = requests.get(\"http://localhost:8000/test\")\n",
+    "response = requests.get(\"http://localhost:8000/\")\n",
     "print(json.loads(response.text))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'Name': 'MDSIST-CNN', 'Short Description': 'This is a Convolutional Neural Network (CNN) model to classify grayscale images from the MNIST dataset.', 'Description': 'The primary intended use of this model is to classify images of handwritten digits from the MNIST datasetinto one of ten categories (0-9). It was specifically designed for image classification tasks withoutrequiring additional fine-tuning or integration into larger applications. This model is ideal for educational, research, and benchmarking purposes within the field of machine learning, particularly in the area of digit recognition.', 'Layers': {'CNN (CNN)': ['Conv2d (conv1): 1-1', 'Conv2d (conv2): 1-2', 'Linear (fc1): 1-3', 'Linear (fc2): 1-4', 'MaxPool2d (pool): 1-5']}, 'Total parameters': 206922, 'Trainable params': 206922, 'Total param bytes': 827688}\n"
+      "{'message': 'OK', 'status-code': 200, 'data': {'Name': 'MDSIST-CNN', 'Short Description': 'This is a Convolutional Neural Network (CNN) model to classify grayscale images from the MNIST dataset.', 'Description': 'The primary intended use of this model is to classify images of handwritten digits from the MNIST dataset into one of ten categories (0-9). It was specifically designed for image classification tasks without requiring additional fine-tuning or integration into larger applications. This model is ideal for educational, research, and benchmarking purposes within the field of machine learning, particularly in the area of digit recognition.', 'Layers': {'CNN (CNN)': ['Conv2d (conv1): 1-1', 'Conv2d (conv2): 1-2', 'Linear (fc1): 1-3', 'Linear (fc2): 1-4', 'MaxPool2d (pool): 1-5']}, 'Total parameters': 206922, 'Trainable params': 206922, 'Total param bytes': 827688}}\n"
      ]
     }
    ],
@@ -373,12 +392,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAGFCAYAAAASI+9IAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAIoUlEQVR4nO3cP2tVWR+G4b0lEFOIEIOFNooWIqIIiljYaWUZMXb6IQRBOwXB2Fhpa+e/SghITKMimEJQGyu1tFESLBSCes50D+8LFue3M+fETK6rzsPazETvWcWstt/v9xsAaJpm01p/AAB/D1EAIEQBgBAFAEIUAAhRACBEAYAQBQBibNAfbNt2mN8BwJAN8v8quykAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAxttYfwJ9NTk522s3MzJQ3ly9fLm927NhR3oxS27blzYcPH8qbx48flzd3794tb5qm2/etrKx0OouNy00BgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgGj7/X5/oB/s8Ook3c3Pz3fanTx5srwZ8Ffg/7x//768WVhYKG+apmk+ffpU3pw4caLTWVX79+8fyaZpmub169flTZffoydPnpQ3i4uL5Q2jN8ifdTcFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgPAg3gjs27evvHn27FmnsyYnJ8ubK1eulDe3b98ub75//17e/O22bdtW3szOznY66/z58+VNlz+3jx49Km/OnTtX3jB6HsQDoEQUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBhb6w9Yb7Zu3VrezM/PlzdTU1PlTdM0za1bt8qbmzdvdjqLpvn161d5s3v37iF8Cfw73BQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAwoN4RePj4+XNzp07h/Alf/bx48eRnfVfs3fv3vLm4cOH5c3BgwfLm1G6f//+Wn8Ca8hNAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYDwSuoItG07srMePHgwsrNGpcvrpTMzM+XN1atXy5t3796VN2fOnClvmqZprl27Vt4cOHCgvFleXi5v+O9wUwAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAID+KNQL/fH9lZN27cKG/u3LlT3nR5aO3ChQvlTdM0zZEjR8qb379/lzfXr18vb7o8ovfz58/ypmm6PYjX6/U6ncXG5aYAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEG1/wNfa2rYd9resC5s21Tt68eLF8qbL42dN0zRjY/U3Dn/8+FHeTExMlDddH4J7+fJleXP27NnyZnl5ubzpYteuXZ12i4uL5c3S0lJ5c+jQofKm679bRmuQv+7dFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQCi/nraBtfr9cqb2dnZ8ubt27flTdM0zenTp8ubzZs3lzcLCwvlzZcvX8qbpmma58+fd9r9rbo+iDc1NVXedPln7nG7jc1NAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACA8iPeXevr06Uh3AE3jpgDA/xAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgPBKKqzC2Fj9j9ClS5c6ndW2bXmzvLzc6Sw2LjcFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgPAgHqzC5ORkeXPq1KlOZ/X7/fLm3r17nc5i43JTACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAgP4sEq9Hq98mZlZaXTWePj4512UOGmAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABAexINV+Pr1a3kzNzfX6azp6elOO6hwUwAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAID+LBKkxMTJQ3e/bsGcKXwL/DTQGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGA8EoqrMKWLVvKm8OHDw/hS/5s0yb/3UeN3xgAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGA8CAejFi/3x/ZWb1eb2Rn8d/gpgBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQbX/A17nath32t8C6s3379vLm8+fPQ/iSP3vz5k15c/To0SF8CX+DQf66d1MAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQAiLG1/gBYz759+1bevHr1qtNZx48fL2+WlpY6ncXG5aYAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQLT9fr8/0A+27bC/BTaEY8eOddrNzc2VN9PT0+XNixcvyhvWh0H+undTACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAgP4gFsEB7EA6BEFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAYG/QHB3w3D4B1zE0BgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGA+Af2jgVcfuXFLgAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAGFCAYAAAASI+9IAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAIqUlEQVR4nO3csavN8R/H8c/hyiSxXZdyBxxhNjCyGO4ki9xF146BRSZFFv+ArlDuwmRAIouBRdRNRJEbpWxKDN/f9upXP/U775PjcD0e83l1PoPO834Gn17XdV0DgNbainEfAIA/hygAEKIAQIgCACEKAIQoABCiAECIAgAxMegHe73eKM8BwIgN8n+V3RQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgJgY9wFgFLZt21bePHjwoLzZsGFDeTOsCxculDenT58ewUlYztwUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAMKDeCxLc3Nz5c3k5GR5c/369fJmaWmpvGmttQ8fPgy1gwo3BQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYDodV3XDfTBXm/UZ4GfunjxYnlz/Pjx8mbFivrfSHv37i1vHj9+XN7ArzDIz72bAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAEBMjPsA/Du2bt061O7IkSPlzTCP250/f768efr0aXkDfzI3BQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYDodV3XDfTBXm/UZ2GZe/78+VC7nTt3ljd3794tb2ZmZsqbHz9+lDcwLoP83LspABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABAT4z4Af6dDhw6VN/1+fwQn+bknT56UN148BTcFAP6LKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgDhQTyGsmbNmvJmYmK4f24fPnwoby5fvjzUd8G/zk0BgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIDyIx1D6/f5v+675+fny5v379yM4CSx/bgoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIA0eu6rhvog73eqM/CX2Rpaam8mZycHOq7hnl879WrV0N9Fyxng/zcuykAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEBPjPgDjNzU1Vd6sXr16BCcBxs1NAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACA8iEebmZkpb9avXz+CkwDj5qYAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEB7Eo33+/Lm8+fHjR3mzatWq8uZ3Wrt2bXmzZcuW8ubo0aPlTWutTU9PD7WrunLlSnmzsLDw6w/CWLgpABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAESv67puoA/2eqM+C3+RpaWl8mZycnKo7+r3++XNunXryptLly6VN7t37y5vvn79Wt601tqbN2/Km82bN5c3K1bU/1a8detWeXPixInyprXWvnz5MtSO1gb5uXdTACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAIiJcR8A/p+5ubny5u3bt+XNzp07y5uTJ0+WN8+ePStvWmvt4cOH5c2ePXvKm1OnTpU3s7Oz5c2jR4/Km9Zam5+fH2rHYNwUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAIhe13XdQB/s9UZ9Fv4iL168KG927NgxgpP8Ojdu3ChvDh8+PIKTjFe/3y9vFhcXy5s7d+6UN621duDAgaF2tDbIz72bAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAEBMjPsA/J3OnTtX3ly7dm2o71q5cmV58+3bt/LmwoUL5Q3D27Vr17iPwE+4KQAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEB/EYysLCQnlz5syZob5r+/bt5c2nT5/Km+/fv5c3f7qtW7eWN2fPnh3BSf7X7du3f8v3UOOmAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABC9ruu6gT7Y6436LCxz/X5/qN29e/fKm40bN5Y37969K28uXbpU3szPz5c3rbU2Oztb3hw/fry8mZ6eLm8+fvxY3uzfv7+8aa21xcXFoXa0NsjPvZsCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQHgQjz/etm3bypv79++XN1NTU+XNcvTp06fyZt++feWNh+1+Pw/iAVAiCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgDhlVSWpWFeVj148GB5c+zYsfJm06ZN5U1rrV29erW8ef36dXlz8+bN8ubly5flDb+fV1IBKBEFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIDyIB/CP8CAeACWiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQE4N+sOu6UZ4DgD+AmwIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgDxH4+x/8VIiICcAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
       ]
@@ -390,63 +409,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{\"prediction\":[2]}\n"
+      "{\"detail\":[{\"type\":\"missing\",\"loc\":[\"body\",\"files\"],\"msg\":\"Field required\",\"input\":null}]}\n"
      ]
     }
    ],
    "source": [
     "# Set the headers to indicate the content type as 'application/octet-stream'\n",
-    "headers = {'Content-Type': 'application/octet-stream'}\n",
-    "resp = requests.post(\"http://localhost:8000/mnist-model-prediction\", headers=headers,data=get_img_bytes(4))\n",
-    "print(resp.text)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 87,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAGFCAYAAAASI+9IAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAIoUlEQVR4nO3cP2tVWR+G4b0lEFOIEIOFNooWIqIIiljYaWUZMXb6IQRBOwXB2Fhpa+e/SghITKMimEJQGyu1tFESLBSCes50D+8LFue3M+fETK6rzsPazETvWcWstt/v9xsAaJpm01p/AAB/D1EAIEQBgBAFAEIUAAhRACBEAYAQBQBibNAfbNt2mN8BwJAN8v8quykAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAxttYfwJ9NTk522s3MzJQ3ly9fLm927NhR3oxS27blzYcPH8qbx48flzd3794tb5qm2/etrKx0OouNy00BgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgGj7/X5/oB/s8Ook3c3Pz3fanTx5srwZ8Ffg/7x//768WVhYKG+apmk+ffpU3pw4caLTWVX79+8fyaZpmub169flTZffoydPnpQ3i4uL5Q2jN8ifdTcFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgPAg3gjs27evvHn27FmnsyYnJ8ubK1eulDe3b98ub75//17e/O22bdtW3szOznY66/z58+VNlz+3jx49Km/OnTtX3jB6HsQDoEQUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBhb6w9Yb7Zu3VrezM/PlzdTU1PlTdM0za1bt8qbmzdvdjqLpvn161d5s3v37iF8Cfw73BQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAwoN4RePj4+XNzp07h/Alf/bx48eRnfVfs3fv3vLm4cOH5c3BgwfLm1G6f//+Wn8Ca8hNAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYDwSuoItG07srMePHgwsrNGpcvrpTMzM+XN1atXy5t3796VN2fOnClvmqZprl27Vt4cOHCgvFleXi5v+O9wUwAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAID+KNQL/fH9lZN27cKG/u3LlT3nR5aO3ChQvlTdM0zZEjR8qb379/lzfXr18vb7o8ovfz58/ypmm6PYjX6/U6ncXG5aYAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEG1/wNfa2rYd9resC5s21Tt68eLF8qbL42dN0zRjY/U3Dn/8+FHeTExMlDddH4J7+fJleXP27NnyZnl5ubzpYteuXZ12i4uL5c3S0lJ5c+jQofKm679bRmuQv+7dFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQCi/nraBtfr9cqb2dnZ8ubt27flTdM0zenTp8ubzZs3lzcLCwvlzZcvX8qbpmma58+fd9r9rbo+iDc1NVXedPln7nG7jc1NAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACA8iPeXevr06Uh3AE3jpgDA/xAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgPBKKqzC2Fj9j9ClS5c6ndW2bXmzvLzc6Sw2LjcFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgPAgHqzC5ORkeXPq1KlOZ/X7/fLm3r17nc5i43JTACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAgP4sEq9Hq98mZlZaXTWePj4512UOGmAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABAexINV+Pr1a3kzNzfX6azp6elOO6hwUwAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAID+LBKkxMTJQ3e/bsGcKXwL/DTQGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGA8EoqrMKWLVvKm8OHDw/hS/5s0yb/3UeN3xgAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGA8CAejFi/3x/ZWb1eb2Rn8d/gpgBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQbX/A17nath32t8C6s3379vLm8+fPQ/iSP3vz5k15c/To0SF8CX+DQf66d1MAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQAiLG1/gBYz759+1bevHr1qtNZx48fL2+WlpY6ncXG5aYAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQLT9fr8/0A+27bC/BTaEY8eOddrNzc2VN9PT0+XNixcvyhvWh0H+undTACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAgP4gFsEB7EA6BEFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAYG/QHB3w3D4B1zE0BgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGA+Af2jgVcfuXFLgAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 640x480 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAGFCAYAAAASI+9IAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAI8klEQVR4nO3cz4uP6x/H8fsjP1YWk5RDUZSNFZKyYEFIFEWxYONY2JxwDGsLiYSMlY1/gKUkNrNRxs8iSxYnFufUmVJSs3Cf3au+5VvzvjIfc+Y8Hut5dd1S83QtXIO+7/sOALqum/ezPwCA2UMUAAhRACBEAYAQBQBCFAAIUQAgRAGAmD/dHxwMBjP5HQDMsOn8X2U3BQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQAiPk/+wPgv2bRokVNu23btv3gL/l3evv2bXnz6dOnGfiSuclNAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACA8iMecNDIyUt4cPny4vDl48GB5s27duvKm67pu6dKl5c1gMChv+r4vb4bp8+fP5U3L3+3Dhw/Lm7nATQGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGA8Eoqs97WrVvLm8uXL5c3mzdvLm/+/PPP8ubNmzflTdd13cuXL8ublldSJycny5sPHz6UN+vXry9vuq7r9uzZU94cOXKkvJmamipvRkdHy5uua/szzRQ3BQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYDwIB5Ds2PHjqbd3bt3y5u//vqrvDl58mR5c+fOnfKm5aG1uWhiYqJpt2XLlvLm6NGj5c2GDRvKm6tXr5Y3s42bAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAEAM+r7vp/WDg8FMfwtz3JMnT5p2y5YtK2/OnTtX3rQ8vDcXrV27trzZs2dPeTM6OlredF3X/fLLL+XNtWvXypuLFy+WN5OTk+XNME3n172bAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAEDM/9kfwL/TgQMHyptNmzY1ndXymNlcfNxuZGSkvLl582Z5s3///vJmwYIF5c3Y2Fh503Vdd+/evfJmYmKivPn27Vt5Mxe4KQAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQXkmlSctLmvPmtf0b5P79+027YVi5cmV5c+zYsaazfv311/Km5fsePHhQ3ly8eLG8efLkSXnDzHNTACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAgP4jE079+/b9q9evWqvFm9enV5Mzo6Wt7s2rWrvFm1alV503Vd9/jx4/LmxIkT5c34+Hh5MzU1Vd4wO7kpABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQH8WgyGAzKmzVr1jSdde/evfJmx44dTWdVPX36tLw5dOhQ01kvXrxo2kGFmwIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAeBCPJn3fD2XTdV23ffv28ubvv/8ub27cuFHeXL9+vbz58uVLeQPD4qYAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEB7Eozt06FB5s3fv3hn4ku979uxZefPbb7+VNxMTE+UNzDVuCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEV1LnmPPnz5c3v//+e3kzMjJS3vR9X950XdeNj4+XN148hTZuCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgDhQbxZavfu3U27S5cu/eAv+b4LFy6UN6dOnWo6azAYNO2AOjcFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgPAg3hAsXry4vLl9+3bTWVNTU+XNgQMHypsHDx6UNzt37ixvuq7r+r5v2gF1bgoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIA4UG8ITh+/Hh5s2LFiqazzp49W960PG7X4t27d0M5B2jnpgBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQHsQbgtHR0fJmcnKy6ay7d+827YZh48aNTbtHjx794C8B/h83BQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQDCK6lDsHz58vLm1q1bTWf98ccfTbuqJUuWlDerVq1qOmswGDTtgDo3BQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYDwIN4QPH/+vLzZt29f01lfv35t2lUdP368vPn48WPTWWNjY007oM5NAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACAGfd/30/rBwWCmv2XOOn36dHlz5cqVprPmzRtO51+/fl3enDlzpums8fHxph3wv6bz695NAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACA8iDdLbdu2rWm3cOHCH/wl3/fo0aOhnAP8OB7EA6BEFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQDCK6kA/xFeSQWgRBQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAYv50f7Dv+5n8DgBmATcFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUA4h+9IguDRyyMJgAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 640x480 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAGFCAYAAAASI+9IAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAJC0lEQVR4nO3cvW+Oix/H8euWLp4STx1YCOmgC0kNJqmFgUHiDxBGE4mkEgYJYakBA6aTIBHRIBIMjclgsQqDUJOE1kO6ibh/w0k+yzm/pN/ruG/Vvl6zT64rTeXtGnw73W632wBA0zRLfvcLADB/iAIAIQoAhCgAEKIAQIgCACEKAIQoABADc/2DnU6nl+8BQI/N5f8q+1IAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACAGfvcL8GuNjY2VN8PDw+XN1atXy5ujR4+WN03TNN1ut7yZmpoqb5YvX17eDA4OljedTqe8aZqmuXfvXnnz4MGDVs9i8fKlAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCd7hyvjbU94kU7u3fvbrW7c+dOebNmzZpWz6pq+zvU5iDefNb25zA7O1veHD58uLy5f/9+ecOfYS5/l3wpABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAMTA736BxWDXrl3lzd27d1s9a9WqVa1289mXL1/Km0ePHvXgTX6NkZGRVrutW7eWN3/99Vd50+YA4YMHD8ob5idfCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEK6l9sH///vJmvl87ffHiRXlz9uzZVs96/vx5efP58+dWz+qHlStXttrt2LGjvJmcnCxvbt68Wd5s3ry5vPn06VN5Q+/5UgAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIB/H6YHR0tLzpdDq//kX+j1u3bpU3hw4d6sGbLA6zs7Otdi9fvixv3rx5U94MDQ2VNydOnChvxsbGyht6z5cCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQDiI1wcjIyPlTbfb7cGb/LvHjx/37Vm09/Hjx/Lm6tWr5c3FixfLm8HBwfKG+cmXAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAEA4iNcHExMT5c3evXtbPev27dvljYN4C9erV6/68pxly5b15Tn0ni8FAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAMKV1D44duxYebN8+fJWz3rz5k2rHQvT1NRUeTM9PV3evH//vrxhfvKlAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABAO4vXBhw8ffvcrsEgdPHiwvFm3bl0P3oQ/hS8FAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgHAQD/4Q27ZtK2/OnTvXgzdhIfOlAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABAO4sEfYnBwsLzpdrs9eJN/mp6e7stz6D1fCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgDhIB7Nhg0byptDhw6VN6Ojo+VN0/TvqFu/dDqdVrvh4eFf/Cb/7unTp+XNpUuXevAm/A6+FAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFACITneOJyjbXnZk/pucnCxvdu/eXd60/R1yJfVv/fo5fP36tbw5depUeXP9+vXyhv9mLr9DvhQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAwkG8BWbTpk3lzbNnz8qb9evXlzfz/RBcv/g5/O3GjRutdkeOHPnFb7J4OIgHQIkoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCAOEg3gKzZ8+e8ubJkyc9eJN/Onv2bKvdxMREefPw4cPyZuPGjeVNG0uWtPu32Pfv38ubmZmZ8mbt2rXlzcDAQHnT9ufw8+fP8mZ8fLy8OX/+fHnz7du38qafHMQDoEQUAAhRACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgHAQb4HZuXNneTM5OVneLF26tLxp+zs0x1/RP8bbt29b7Y4fP17ePHr0qLzZt29feXPy5MnyZmhoqLxpmqZZt25dq13Vu3fvypvLly+3etaVK1da7aocxAOgRBQACFEAIEQBgBAFAEIUAAhRACBEAYAQBQBCFAAIUQAgRAGAcBCP5vTp0+XNmTNnypuFeBBvfHy8vLl27VqrZ01NTbXazVfbt29vtbtw4UJ5MzIyUt6sWbOmvHn//n150zRNs2XLlla7KgfxACgRBQBCFAAIUQAgRAGAEAUAQhQACFEAIEQBgBAFAEIUAAhRACBEAYBwJZVm9erV5c2BAwfKm9HR0fKmadpdSW1zUXRiYqK8ef36dXnz48eP8ob/ZtOmTeXNihUrypuZmZnypmma5sOHD612Va6kAlAiCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAEA4iAewSDiIB0CJKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAhCgAEKIAQIgCACEKAIQoABCiAECIAgAhCgCEKAAQogBAiAIAIQoAxMBc/2C32+3lewAwD/hSACBEAYAQBQBCFAAIUQAgRAGAEAUAQhQACFEAIP4Hwls3Ozh7ofkAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 640x480 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{\"prediction\":[2,8,4]}\n"
-     ]
-    }
-   ],
-   "source": [
-    "headers = {'Content-Type': 'application/octet-stream'}\n",
-    "resp = requests.post(\"http://localhost:8000/mnist-model-prediction\", headers=headers,data=get_img_bytes(4)+get_img_bytes(85)+get_img_bytes(66))\n",
+    "#headers = {'Content-Type': 'application/octet-stream'}\n",
+    "resp = requests.post(\"http://localhost:8000/mnist-model-prediction\",data={\"format\":\"raw\"} ,files=[('data',get_img_bytes([7]))])\n",
     "print(resp.text)"
    ]
   },
@@ -459,7 +429,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -475,7 +445,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -484,7 +454,7 @@
        "'Linear (fc1): 1-3'"
       ]
      },
-     "execution_count": 89,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/tests/mdsist/test_api.py
+++ b/tests/mdsist/test_api.py
@@ -10,28 +10,25 @@ from mdsist.config import PROCESSED_DATA_DIR
 from mdsist.dataset import MdsistDataset
 
 
-def get_img_bytes(ind):
+def get_img(ind):
     """Gets the label and bytes of the image indexed by ind in the test dataset"""
 
     test_dataset = MdsistDataset(PROCESSED_DATA_DIR / "test.parquet")
     image_dict = test_dataset.data.loc[ind, "image"]
-    image_array = test_dataset.decode_png_image(image_dict)
     label = test_dataset.data.loc[ind, "label"]
-    image = image_array.tobytes()
-    return image, label
+    return image_dict["bytes"], label
 
 
-def get_multiple_img_bytes(inds):
-    """Returns the concatenation of the bytes and the
-    array of labels of all the images indexed by inds
-    (index array)"""
+def get_multiple_png_images(inds):
+    """Returns the array of images and labels of
+    all the images indexed by inds(index array)"""
 
-    images = bytes(0)
+    images = []
     labels = []
 
     for ind in inds:
-        image, label = get_img_bytes(ind)
-        images += image
+        image, label = get_img(ind)
+        images.append(("files", image))
         labels.append(label)
 
     return images, (labels)
@@ -58,10 +55,10 @@ def test_get_info(client):
     """Testing of the info endpoint"""
 
     desc = (
-        "The primary intended use of this model is to classify"
-        "images of handwritten digits from the MNIST dataset"
+        "The primary intended use of this model is to classify "
+        "images of handwritten digits from the MNIST dataset "
         "into one of ten categories (0-9). It was specifically "
-        "designed for image classification tasks without"
+        "designed for image classification tasks without "
         "requiring additional fine-tuning or integration into larger applications. "
         "This model is ideal for educational, research, and benchmarking purposes within "
         "the field of machine learning, "
@@ -100,16 +97,15 @@ def test_get_info(client):
 
 @pytest.mark.parametrize(
     ["sample", "expected"],
-    [get_img_bytes(i) for i in [85, 60]],
+    [get_multiple_png_images([85])],
 )
 def test_predict_one_number(client, sample, expected):
     """Testing of the predict endpoint with one image"""
 
-    headers = {"Content-Type": "application/octet-stream"}
+    print(sample)
     response = client.post(
         "/mnist-model-prediction",
-        headers=headers,
-        content=sample,
+        files=sample,
         timeout=30,
     )
 
@@ -117,20 +113,18 @@ def test_predict_one_number(client, sample, expected):
     assert response.status_code == 200
     assert json["message"] == "OK"
     assert json["status-code"] == 200
-    assert json["data"]["prediction"][0] == expected
+    assert json["data"]["prediction"] == expected
 
 
 @pytest.mark.parametrize(
     ["samples", "expectations"],
-    [(get_multiple_img_bytes([85, 60]))],
+    [(get_multiple_png_images([85, 60]))],
 )
 def test_predict_multiple_numbers(client, samples, expectations):
     """Testing of the predict endpoint with multiple images"""
-    headers = {"Content-Type": "application/octet-stream"}
     response = client.post(
         "/mnist-model-prediction",
-        headers=headers,
-        content=samples,
+        files=samples,
         timeout=30,
     )
 


### PR DESCRIPTION
There was a bug that was making the prediction endpoint not work properly. A transformation step was missing for the inopt data.
Now the prediction endpoint accepts one, or more png images directly instead of a bytearray.